### PR TITLE
Fix PATH error

### DIFF
--- a/scripts/apt-install.sh
+++ b/scripts/apt-install.sh
@@ -3,7 +3,6 @@
 # --- Linux/WSL Setup Scripts ---
 # Install applicatiyons
 
-source ./utils.sh
 keep_sudo_alive
 
 e_header "Starting application install (apt-install.sh)"

--- a/scripts/dotfile-install.sh
+++ b/scripts/dotfile-install.sh
@@ -3,7 +3,6 @@
 # --- Linux/WSL Setup Scripts ---
 # Install dot files
 
-source ./utils.sh
 keep_sudo_alive
 
 e_header "Starting dot file installations (dotfile-install.sh)"

--- a/scripts/node-install.sh
+++ b/scripts/node-install.sh
@@ -3,7 +3,6 @@
 # --- Linux/WSL Setup Scripts ---
 # Install applications
 
-source ./utils.sh
 keep_sudo_alive
 
 e_header "Starting nvm and nodejs install (node-install.sh)"

--- a/scripts/npm-install.sh
+++ b/scripts/npm-install.sh
@@ -3,7 +3,6 @@
 # --- Linux/WSL Setup Scripts ---
 # Install global npm packages
 
-source ./utils.sh
 keep_sudo_alive
 
 e_header "Starting global npm package installation (npm-install.sh)"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,7 +7,22 @@
 #
 ## Referenced from: https://github.com/samuelramox/wsl-setup/blob/master/install/utils.sh
 
-source ./utils.sh
+# http://www.gnu.org/software/bash/manual/bashref.html#The-Set-Builtin
+# Use the set command:
+# -a: Mark variables and function which are modified or created for export to the environment of subsequent commands.
+set -a
+# Put variables that will be marked for export in here.
+# These will be available from within other scripts and other commands.
+# If script2 modifies these variables, the modifications will not be present in the other scripts.
+
+# 
+# https://stackoverflow.com/a/246128
+# "Is a useful one-liner which will give you the full directory name of the script no matter where it is being called from."
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $DIR/utils.sh
+
+set +a
+
 keep_sudo_alive
 
 e_header "Startng main setup script"


### PR DESCRIPTION
Fix `PATH` error when running `setup.sh` from a directory other than `dotfiles/scripts`. 

By using `set -a` you can remove the explicit `source ./utils.sh` from your other scripts. You are able to pass your variables and functions from `utils.sh` to any script you call from `setup.sh`. You can override these values within other scripts, and doing so will not effect other scripts being called after.